### PR TITLE
Add multi led

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ number:
   > required: true | type: [int]
 - unique_id: The unique ID of the light.
   > required: false | default: None | type: string
+- multi: If the LED should switch multiple LED pins.
+  > required: false | default: false | type: boolean
 
 ***number specific settings:***
 - numbers: List of the numbers.
@@ -118,6 +120,11 @@ light:
       - name: Lightstrip RGBW
         unique_id: lightstrip_rgbw
         pins: [1,2,4,6]
+        address: 65
+      - name: Lightstrip Multiple
+        unique_id: lightstrip_multiple
+        pins: [1,2,3]
+        multi: true
         address: 65
 
 number:

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -23,6 +23,11 @@ light:
         unique_id: lightstrip_rgbw
         pins: [1,2,4,6]
         address: 65
+      - name: Lightstrip Multiple
+        unique_id: lightstrip_multiple
+        pins: [1,2,3]
+        multi: true
+        address: 65
 
 number:
   - platform: pca9685

--- a/custom_components/pca9685/const.py
+++ b/custom_components/pca9685/const.py
@@ -9,6 +9,7 @@ CONF_INVERT = "invert"
 CONF_STEP = "step"
 CONF_LEDS = "leds"
 CONF_PINS = "pins"
+CONF_MULTI = "multi"
 
 MODE_SLIDER = "slider"
 MODE_BOX = "box"


### PR DESCRIPTION
Control multiple pwm pins as one light in homeassistant:

Example:
```yml
light:
  - platform: pca9685
    leds:
      - name: Lightstrip Multiple
        pins: [1,2,5,6]
        multi: true
```